### PR TITLE
3.4.1: Fixes, typos, wizards & optimization

### DIFF
--- a/scenes/tagit_main_window.gd
+++ b/scenes/tagit_main_window.gd
@@ -489,7 +489,7 @@ func _on_files_dropped(files: PackedStringArray) -> void:
 func _on_tool_tag_requested() -> void:
 	var tags: Array[String] = []
 	
-	for list_index in range(alt_lists.size()):
+	for list_index in range(alt_lists.size() - 1):
 		if list_index == current_alt:
 			var new_tags: Array[String] = []
 			for tag in tags_tree.get_root().get_children():
@@ -1500,6 +1500,7 @@ func on_new_blacklist() -> void:
 func new_list() -> void:
 	current_title = ""
 	current_project_uuid = ""
+	current_alt = 0
 	_suggestion_blacklist.clear()
 	_group_blacklist.clear()
 	clear_all_tagger()
@@ -1514,7 +1515,7 @@ func clear_all_tagger() -> void:
 	project_image.texture = null
 	clear_img_btn.disabled = true
 	reset_view_button.disabled = true
-	for alt in range(1, alt_opt_btn.item_count):
+	for alt in range(alt_opt_btn.item_count -1, 0, -1):
 		alt_opt_btn.remove_item(alt)
 		generate_version_opt_btn.remove_item(alt)
 	alt_opt_btn.select(0)
@@ -1533,6 +1534,10 @@ func clear_all_tagger() -> void:
 
 func on_selector_project_saved(title: String) -> void:
 	selector.set_emit_signals(false)
+	if SingletonManager.TagIt.verbose:
+		SingletonManager.TagIt.log_silent(
+				"[TagIt] Saving project with UUID: " + current_project_uuid,
+				DataManager.LogLevel.INFO)
 	var projects := TagItProjectResource.get_projects()
 	var alts: Array[Dictionary] = []
 	
@@ -1575,6 +1580,10 @@ func on_selector_project_saved(title: String) -> void:
 
 func on_selector_project_selected(project_uuid: String) -> void:
 	selector.set_emit_signals(false)
+	if SingletonManager.TagIt.verbose:
+		SingletonManager.TagIt.log_silent(
+				"[TagIt] Opening project with UUID: " + project_uuid,
+				DataManager.LogLevel.INFO)
 	var request_suggestions: bool = SingletonManager.TagIt.settings.request_suggestions
 	SingletonManager.TagIt.settings.request_suggestions = false
 	
@@ -1644,6 +1653,10 @@ func on_selector_project_selected(project_uuid: String) -> void:
 
 
 func on_selector_project_deleted(project_uuid: String) -> void:
+	if SingletonManager.TagIt.verbose:
+		SingletonManager.TagIt.log_silent(
+				"[TagIt] Deleting project with UUID: " + project_uuid,
+				DataManager.LogLevel.INFO)
 	var projects := TagItProjectResource.get_projects()
 	projects.delete_project(project_uuid)
 	projects.save()
@@ -2133,7 +2146,8 @@ func on_wiki_searched(search_text: String) -> void:
 	wiki_search_ln_edt.editable = false
 	wiki_search_btn.disabled = true
 	
-	if SingletonManager.TagIt.has_tag(wiki_search) and SingletonManager.TagIt.has_data(SingletonManager.TagIt.get_tag_id(wiki_search)):
+	
+	if SingletonManager.TagIt.has_tag(wiki_search) and SingletonManager.TagIt.has_tag_data(wiki_search):
 		var tag_data := SingletonManager.TagIt.get_tag_data(SingletonManager.TagIt.get_tag_id(wiki_search))
 		wiki_title_lbl.text = Strings.title_case(tag_data["tag"])
 		wiki_rtl.text = tag_data["description"]
@@ -2157,6 +2171,8 @@ func on_wiki_searched(search_text: String) -> void:
 		wiki_section_separator.visible = wiki_parents_container.visible or wiki_aliases_container.visible
 		
 		if SingletonManager.TagIt.settings.load_wiki_images and hydrus_connected:
+			wiki_reload_images_button.disabled = true
+			thumbnail_size_changer.disabled = true
 			var files = await search_hydrus_files(
 					Array([wiki_search], TYPE_STRING, &"", null),
 					SingletonManager.TagIt.settings.wiki_images)
@@ -2336,7 +2352,7 @@ func add_tag(tag_name: String, clean_suggestions: bool = true, skip_suggestions:
 
 
 func on_esix_api_suggestions_found(for_tag: String, suggestions: Array[String]) -> void:
-	if for_tag.is_empty():
+	if for_tag.is_empty() or suggestions.is_empty():
 		return
 	
 	if tags_tree.has_tag(for_tag):
@@ -2762,7 +2778,7 @@ func json_tag_to_db(data: Dictionary, overwrite: bool = false) -> void:
 		group_id = SingletonManager.TagIt.create_tag_group(data["group"], data["group_desc"])
 		group_sugg_data[group_id] = {"name": data["group"], "description": data["group_desc"]}
 	
-	if SingletonManager.TagIt.has_tag(clean_name) and SingletonManager.TagIt.has_data(SingletonManager.TagIt.get_tag_id(clean_name)):
+	if SingletonManager.TagIt.has_tag(clean_name) and SingletonManager.TagIt.has_tag_data(clean_name):
 		if overwrite:
 			var tag_id: int = SingletonManager.TagIt.get_tag_id(clean_name)
 			SingletonManager.TagIt.update_tag_data(
@@ -2974,7 +2990,7 @@ func json_group_to_db(json_result: Dictionary, overwrite: bool = false) -> void:
 		var group_id: int = 0 if not json_groups.has(int(tag["group"])) else json_groups[int(tag["group"])]
 		var cat_id: int = 1 if not json_cats.has(int(tag["category"])) else json_cats[int(tag["category"])]
 		
-		if SingletonManager.TagIt.has_tag(clean_tag) and SingletonManager.TagIt.has_data(SingletonManager.TagIt.get_tag_id(clean_tag)):
+		if SingletonManager.TagIt.has_tag(clean_tag) and SingletonManager.TagIt.has_tag_data(clean_tag):
 			if overwrite:
 				var _tag_id: int = SingletonManager.TagIt.get_tag_id(clean_tag)
 				SingletonManager.TagIt.update_tag(_tag_id, {"is_valid": tag["is_valid"]})

--- a/scenes/tagit_main_window.gd
+++ b/scenes/tagit_main_window.gd
@@ -2857,11 +2857,11 @@ func notify_import(multiple: bool = false, success: bool = true) -> void:
 
 func json_group_to_db(json_result: Dictionary, overwrite: bool = false) -> void:
 	var cats_data := SingletonManager.TagIt.get_categories()
-	var groups_data := SingletonManager.TagIt.get_tag_groups()
+	var groups_data := SingletonManager.TagIt.get_tag_groups() # id: Dict
 	
 	var all_icons: Dictionary = {} # name: -> ID
 	var all_cats: Dictionary = {}
-	var all_groups: Dictionary = {}
+	var all_groups: Dictionary = {} # name.to_lower() -> ID
 	
 	var json_icons: Dictionary = {} # idx -> ID
 	var json_cats: Dictionary = {}
@@ -2941,7 +2941,7 @@ func json_group_to_db(json_result: Dictionary, overwrite: bool = false) -> void:
 			continue
 		
 		group_id = SingletonManager.TagIt.create_tag_group(group_dict["name"], group_dict["description"])
-		all_groups[group_id] = {"name": group_dict["name"], "description": group_dict["description"]}
+		all_groups[group_dict["name"].to_lower()] = group_id #{"name": group_dict["name"], "description": group_dict["description"]}
 		json_groups[group_idx] = group_id
 	
 	var empty_tags: Dictionary = {}
@@ -3027,9 +3027,9 @@ func json_group_to_db(json_result: Dictionary, overwrite: bool = false) -> void:
 		var group_suggestions: Array[int] = []
 	
 		for group_text in tag["group_suggestions"]:
-			for _group_id in groups_data:
-				if Strings.nocasecmp_equal(group_text, groups_data[_group_id]["name"]):
-					group_suggestions.append(_group_id)
+			for group_name in all_groups:
+				if Strings.nocasecmp_equal(group_text, group_name):
+					group_suggestions.append(all_groups[group_name])
 					break
 		
 		if not tag["parents"].is_empty():

--- a/scenes/tags_tree_script.gd
+++ b/scenes/tags_tree_script.gd
@@ -192,7 +192,7 @@ func add_alt_list(alt_list_name: String) -> void:
 
 
 func clear_popup_alts() -> void:
-	for alt in range(2, alt_list_submenu.item_count):
+	for alt in range(alt_list_submenu.item_count - 1, 1, -1):
 		alt_list_submenu.remove_item(alt)
 	_current_alt = 0
 	alt_list_submenu.set_item_disabled(1, true)

--- a/scenes/tools/tag_fetcher.gd
+++ b/scenes/tools/tag_fetcher.gd
@@ -220,14 +220,28 @@ func load_tags(tags: Array[String]) -> void:
 
 
 func on_save_pressed() -> void:
+	var new_tags: Dictionary = {}
 	for tag:String in fetched_tags:
-		SingletonManager.TagIt.create_tag(
-				tag,
-				1,
-				fetched_tags[tag]["wiki"],
-				0)
-		
-		var tag_id: int = SingletonManager.TagIt.get_tag_id(tag)
+		new_tags[tag] = {
+					"category_id": 1,
+					"description": null if fetched_tags[tag]["wiki"].is_empty() else fetched_tags[tag]["wiki"],
+					"priority": 0,
+					"group_id": null,
+					"tooltip": null
+				}
+	
+	# Batch-create tags
+	SingletonManager.TagIt.create_empty_tags(
+			Array(new_tags.keys(), TYPE_STRING, &"", null))
+	
+	# tag: id
+	var new_ids: Dictionary = SingletonManager.TagIt.get_tags_ids(
+			Array(new_tags.keys(), TYPE_STRING, &"", null))
+	
+	
+	for tag in new_ids:
+		var tag_id: int = new_ids[tag]
+		new_tags[tag]["tag_id"] = tag_id
 		SingletonManager.TagIt.add_parents(
 				tag_id,
 				fetched_tags[tag]["parents"])
@@ -238,6 +252,8 @@ func on_save_pressed() -> void:
 		SingletonManager.TagIt.add_aliases(
 				fetched_tags[tag]["aliases"],
 				tag)
+	
+	SingletonManager.TagIt.set_data_columns(new_tags)
 	
 	if not fetched_tags.is_empty():
 		for tag_tree in queue_tree.get_root().get_children():

--- a/scenes/update_window.tscn
+++ b/scenes/update_window.tscn
@@ -88,11 +88,11 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_1u7h1")
 layout_mode = 2
 size_flags_vertical = 3
 bbcode_enabled = true
-text = "[font_size=20][b][color=SKY_BLUE]New[/color][/b][/font_size]
-[ul] Updted TagIt for the new launcher coming soon.[/ul]
+text = "[font_size=20][b][color=SKY_BLUE]Fixes[/color][/b][/font_size]
+[ul] Fixed error when a tag request returned with no suggestions.
+ Fixed alt-lists breaking when creating a new project.
+ Fixed index error when importing tag from project to batch download tags.
+ Fixed an error with TagIt believing you were on an alt list on new or just opened projects. [/ul]
 
-[font_size=20][b][color=SKY_BLUE]Fixes[/color][/b][/font_size]
-[ul] Fixed typo on wizard.
- Fixed settings not displaying icons/groups after tag import.
- Fixed GodotGIF plugin error on close.[/ul]
-"
+[font_size=20][b][color=SKY_BLUE]Changes[/color][/b][/font_size]
+[ul] Slightly improved tag import speed[/ul]"

--- a/scenes/update_window.tscn
+++ b/scenes/update_window.tscn
@@ -88,11 +88,16 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_1u7h1")
 layout_mode = 2
 size_flags_vertical = 3
 bbcode_enabled = true
-text = "[font_size=20][b][color=SKY_BLUE]Fixes[/color][/b][/font_size]
+text = "[font_size=20][b][color=SKY_BLUE]New[/color][/b][/font_size]
+[ul] Added more items to character properties in the wizard.[/ul]
+
+[font_size=20][b][color=SKY_BLUE]Fixes[/color][/b][/font_size]
 [ul] Fixed error when a tag request returned with no suggestions.
  Fixed alt-lists breaking when creating a new project.
  Fixed index error when importing tag from project to batch download tags.
- Fixed an error with TagIt believing you were on an alt list on new or just opened projects. [/ul]
+ Fixed an error with TagIt believing you were on an alt list on new or just opened projects.
+ Fixed an issue with the importer where it didn't assing group suggestions correctly to tags.
+ Fixed several typos on the wizard.[/ul]
 
 [font_size=20][b][color=SKY_BLUE]Changes[/color][/b][/font_size]
 [ul] Slightly improved tag import speed[/ul]"

--- a/scripts/e_six_requester.gd
+++ b/scripts/e_six_requester.gd
@@ -345,6 +345,10 @@ func on_timer_timeout() -> void:
 	if not jobs.is_empty():
 		var req_url: Dictionary = jobs.pop_front()
 		SingletonManager.TagIt.log_message("[eSIx API] Making a request to e621", DataManager.LogLevel.INFO)
+		if SingletonManager.TagIt.verbose:
+			SingletonManager.TagIt.log_silent(
+				"[eSix API] URL request: " + req_url["url"] + ". Type: " + str(int(req_url["type"]))
+			)
 		requester.request(req_url["url"], get_headers())
 		var response: Array = await request_get
 		SingletonManager.TagIt.log_message("[eSix API] Response received", DataManager.LogLevel.INFO)
@@ -357,7 +361,9 @@ func on_timer_timeout() -> void:
 func process_response(response: Array, response_type: JobTypes) -> void:
 	if response_type == JobTypes.SUGGESTION:
 		if response.is_empty():
-			suggestions_found.emit("", [])
+			suggestions_found.emit(
+					"",
+					Array([], TYPE_STRING, &"", null))
 			return
 		var suggestion_array: Dictionary = parse_tag_strength(
 				response[0]["related_tags"])

--- a/scripts/tagit_singleton.gd
+++ b/scripts/tagit_singleton.gd
@@ -23,7 +23,7 @@ const SEARCH_WILDCARD: String = "*"
 const DB_VERSION: int = 3
 const PROJECTS_VERSION: int = 2
 const TEMPLATES_VERSION: int = 3
-const TAGIT_VERSION_ARRAY: Array[int] = [3, 4, 0]
+const TAGIT_VERSION_ARRAY: Array[int] = [3, 4, 1]
 const MAX_PARENT_RECURSION: int = 100
 const IMAGE_LIMITS: Vector2i = Vector2i(1000, 1000)
 const LEV_DISTANCE: float = 0.75
@@ -51,6 +51,7 @@ var tag_search_data: PackedStringArray = []
 var settings: AppSettingsRes = null
 var _default_icon_color: Color = Color.WHITE
 var splash_node: CanvasLayer = null
+var verbose: bool = false
 
 
 # Needs to be run on main tagger load.
@@ -69,6 +70,9 @@ func _ready() -> void:
 		DirAccess.make_dir_absolute(TagItProjectResource.get_thumbnails_path())
 	
 	tag_database = SQLite.new()
+	if OS.is_stdout_verbose():
+		verbose = true
+		tag_database.verbosity_level = SQLite.VerbosityLevel.VERBOSE
 	tag_database.path = DATABASE_PATH
 	tag_database.foreign_keys = true
 	
@@ -852,6 +856,13 @@ func create_tag(tag_name: String, tag_category: int, tag_desc: String, tag_group
 	tag_created.emit(tag_name, tag_id)
 
 
+func set_data_columns(columns: Dictionary) -> void:
+	# keys are tags, values are all column data from the data table.
+	tag_database.insert_rows("data", columns.values())
+	for tag in columns:
+		tag_search_data.insert(tag_search_data.bsearch(tag, false), tag)
+
+
 func create_empty_tag(tag_name: String) -> void:
 	var new_tag: Dictionary = {
 		"name": tag_name,
@@ -1271,9 +1282,7 @@ func has_data(tag_id: int) -> bool:
 
 
 func has_tag_data(tag: String) -> bool:
-	if not has_tag(tag):
-		return false
-	return has_data(get_tag_id(tag))
+	return Arrays.binary_search(tag_search_data, tag) != -1
 
 
 func has_tag(tag_name: String) -> bool: 
@@ -1745,7 +1754,7 @@ func log_message(message: String, log_level: LogLevel) -> void:
 	message_logged.emit(log_msg)
 
 
-func log_silent(message: String, log_level: LogLevel) -> void:
+func log_silent(message: String, log_level: LogLevel = LogLevel.INFO) -> void:
 	var log_msg: String = str("[", Time.get_time_string_from_system(), "]")
 	
 	match log_level:

--- a/scripts/tagit_singleton.gd
+++ b/scripts/tagit_singleton.gd
@@ -109,14 +109,13 @@ func _ready() -> void:
 			"name": {"data_type": "text"},
 			"whitespace": {"data_type": "text", "not_null": true},
 			"separator": {"data_type": "text", "not_null": true}}
-		
-		var prefix_table: Dictionary = {
-			"prefix": {"data_type": "text", "primary_key": true, "not_null": true, "unique": true},
-			"format": {"data_type": "text", "default": null}}
-		
+
 		tag_database.create_table("tags", tags_table)
 		tag_database.create_table("icons", icons_table)
-		tag_database.create_table("prefixes", prefix_table)
+		tag_database.query( # prefixes
+				"CREATE TABLE prefixes (
+						prefix TEXT NOT NULL PRIMARY KEY UNIQUE,
+						format TEXT DEFAULT NULL);")
 		tag_database.query( # suggestions
 				"CREATE TABLE suggestions ( 
 					tag_id INTEGER NOT NULL, 

--- a/scripts/wizard_script.gd
+++ b/scripts/wizard_script.gd
@@ -59,7 +59,7 @@ const CLOTHING: Array[Dictionary] = [
 		"options": [
 			"Abuniverse",
 			"Cloth diaper",
-			"Prilly diaper",
+			"Frilly diaper",
 			"Pull-ups (diaper)",
 		],
 		"score": 10
@@ -171,7 +171,7 @@ const BODY_TRAITS: Array[Dictionary] = [
 	{"title": "Slit", "tag": "genital slit"},
 	{"title": "Aroused", "tag": "aroused"},
 	{"title": "Blushing", "tag": "blush"},
-	{"title": "Speaking", "tag": "dialog"},
+	{"title": "Speaking", "tag": "dialogue"},
 	{"title": "Bound", "tag": "bound"},
 	{"title": "Sweating", "tag": "sweat"},
 	]
@@ -210,16 +210,41 @@ const BODY_TYPES: Array[Dictionary] = [
 			"text": "short fur,average length,long fur",
 			"tags": ["short fur", "", "long fur"],
 			"value": 1
-		},
+			},
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "fur markings"],
+				"tooltip": ["Fur markings"]
+			}
 		]},
 	{
 		"name": "Scales",
 		"tag": "scales",
-		"include_standalone": true},
+		"include_standalone": true,
+		"properties": [
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "scale markings"],
+				"tooltip": ["Scale markings"]
+			}
+		]},
 	{
 		"name": "Feathers",
 		"tag": "feathers",
-		"include_standalone": true},
+		"include_standalone": true,
+		"properties": [
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "feather markings"],
+				"tooltip": ["Feather markings"]
+			}
+		]},
 	{
 		"name": "Wool",
 		"tag": "wool",
@@ -231,7 +256,16 @@ const BODY_TYPES: Array[Dictionary] = [
 	{
 		"name": "Exoskeleton",
 		"tag": "exoskeleton",
-		"include_standalone": true},
+		"include_standalone": true,
+		"properties": [
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "exoskeleton markings"],
+				"tooltip": ["Exoskeleton markings"]
+			}
+		]},
 	{
 		"name": "Anus",
 		"tag": "anus",
@@ -266,6 +300,27 @@ const BODY_TYPES: Array[Dictionary] = [
 				"text": "Small,Average,Big,Huge,Hyper",
 				"tags": ["small balls", "", "big balls", "huge balls", "hyper balls"],
 				"value": 1
+			},
+			{
+				"name": "Hang",
+				"mode": TreeItem.CELL_MODE_RANGE,
+				"text": "Tight,Normal,Saggy",
+				"tags": ["tight balls", "", "saggy balls"],
+				"tooltip": ["How low do the balls hang."]
+			},
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "ball markings"],
+				"tooltip": ["Ball markings"]
+			},
+			{
+				"name": "Scrotal Raphe",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has raphe",
+				"tags": ["", "ball markings"],
+				"tooltip": ["Fleshy seam or ridge of tissue running through the middle of the scrotum"]
 			}
 		]},
 	{
@@ -279,6 +334,19 @@ const BODY_TYPES: Array[Dictionary] = [
 				"text": "Flat,Small,Average,Big,Huge,Hyper",
 				"tags": ["flat chested", "small breasts", "medium breasts", "big breasts", "huge breasts", "hyper breasts"],
 				"value": 2
+			},
+			{
+				"name": "Markings",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has markings",
+				"tags": ["", "breast markings"]
+			},
+			{
+				"name": "Featureless",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Are featureless",
+				"tags": ["", "featureless breasts"],
+				"tooltip": ["Breasts without nipples/areola"]
 			}
 		]
 	},
@@ -331,7 +399,8 @@ const BODY_TYPES: Array[Dictionary] = [
 				"mode": TreeItem.CELL_MODE_RANGE,
 				"text": "Black,Blue,Brown,Cyan,Green,Grey,Orange,Pink,Purple,Red,White,Yellow",
 				"tags": ["black sclera", "blue sclera", "brown sclera", "cyan sclera", "green sclera", "grey sclera", "orange sclera", "pink sclera", "purple sclera", "red sclera", "", "yellow sclera"],
-				"value": 10
+				"value": 10,
+				"tooltip": ["The outer area of the eye (around the iris)."]
 			}
 		]},
 	{
@@ -471,6 +540,11 @@ const BODY_TYPES: Array[Dictionary] = [
 				"tags": ["small knot", "", "big knot", "huge knot", "hyper knot"],
 				"value": 1
 			},{
+				"name": "Veiny",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is veiny",
+				"tags": ["", "veiny knot"]
+			},{
 				"name": "Multi knot",
 				"mode": TreeItem.CELL_MODE_CHECK,
 				"text": "Has multiple",
@@ -501,7 +575,7 @@ const BODY_TYPES: Array[Dictionary] = [
 				"tags": ["small areola", "", "big areola", "huge areola", "hyper areola"],
 				"value": 1
 			},{
-				"name": "Multi-nipple (+2)",
+				"name": "Multi-nipple (+3)",
 				"mode": TreeItem.CELL_MODE_CHECK,
 				"text": "Multiple Nipples",
 				"tags": ["", "multi nipple"]
@@ -540,8 +614,14 @@ const BODY_TYPES: Array[Dictionary] = [
 				"name": "Erection",
 				"mode": TreeItem.CELL_MODE_RANGE,
 				"text": "Flaccid (Visible),Half-erect,Erect",
-				"tags": ["flaccid", "hald-erect", "erection"],
+				"tags": ["flaccid", "half-erect", "erection"],
 				"value": 2
+			},
+			{
+				"name": "Veiny",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is veiny",
+				"tags": ["", "veiny penis"]
 			},
 			{
 				"name": "Anatomically correct",
@@ -611,12 +691,12 @@ const BODY_TYPES: Array[Dictionary] = [
 		"name": "Tongue",
 		"tag": "tongue",
 		"include_standalone": true,
-		"propeties": [
+		"properties": [
 			{
 				"name": "Shape",
 				"mode": TreeItem.CELL_MODE_RANGE,
-				"text": "Regular,Forked,Tappering,Segmented,Ribbed",
-				"tags": ["", "forked tongue", "tappering tongue", "segmented tongue", "ribbed tongue"],
+				"text": "Regular,Forked,Tapering,Segmented,Ribbed",
+				"tags": ["", "forked tongue", "tapering tongue", "segmented tongue", "ribbed tongue"],
 			},
 		]
 	},
@@ -650,7 +730,7 @@ const BODY_TYPES: Array[Dictionary] = [
 				"name": "Shape",
 				"mode": TreeItem.CELL_MODE_RANGE,
 				"text": "Innie,Average,Outie",
-				"tags": ["innie pussy", "", "long_labia"],
+				"tags": ["innie pussy", "", "long labia"],
 				"value": 0
 			},
 			{
@@ -665,7 +745,6 @@ const BODY_TYPES: Array[Dictionary] = [
 		"tag": "wings",
 		"include_standalone": true}
 	]
-
 
 var storage: TagItStorage = TagItStorage.get_storage()
 var characters: Array[Dictionary] = []
@@ -1605,6 +1684,13 @@ func add_tree_bodies() -> void:
 				
 				new_prop.set_text(0, property["name"])
 				new_prop.set_metadata(0, {"index": prop_idx})
+				
+				if property.has("tooltip"):
+					var tips: int = property["tooltip"].size()
+					if 2 <= tips and not property["tooltip"][1].is_empty():
+						new_prop.set_tooltip_text(1, property["tooltip"][1])
+					if 1 <= tips and not property["tooltip"][0].is_empty():
+						new_prop.set_tooltip_text(0, property["tooltip"][0])
 				
 				match property["mode"]:
 					TreeItem.CELL_MODE_RANGE:

--- a/scripts/wizard_script.gd
+++ b/scripts/wizard_script.gd
@@ -540,15 +540,15 @@ const BODY_TYPES: Array[Dictionary] = [
 				"tags": ["small knot", "", "big knot", "huge knot", "hyper knot"],
 				"value": 1
 			},{
-				"name": "Veiny",
-				"mode": TreeItem.CELL_MODE_CHECK,
-				"text": "Is veiny",
-				"tags": ["", "veiny knot"]
-			},{
 				"name": "Multi knot",
 				"mode": TreeItem.CELL_MODE_CHECK,
 				"text": "Has multiple",
 				"tags": ["", "multi knot"]
+			},{
+				"name": "Veiny",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is veiny",
+				"tags": ["", "veiny knot"]
 			},
 		]
 	},
@@ -579,6 +579,36 @@ const BODY_TYPES: Array[Dictionary] = [
 				"mode": TreeItem.CELL_MODE_CHECK,
 				"text": "Multiple Nipples",
 				"tags": ["", "multi nipple"]
+			},{
+				"name": "Height",
+				"mode": TreeItem.CELL_MODE_RANGE,
+				"text": "Inverted,Average,Erect",
+				"tags": ["inverted nipples", "", "erect nipples"],
+				"value": 1,
+				"tooltip": [
+					"How far apart the nipple reaches from the breast",
+					"Inverted: When the nipple is retracted into the breast.\nErect: When the nipple is pointing outwards and is longer than normal for the character."]
+			},
+			{
+				"name": "Dip",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Has dip",
+				"tags": ["", "nipple dip"],
+				"tooltip": ["When the nipples have a gentle indentation or slit in them."]
+			},
+			{
+				"name": "Puffy Nipples",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is puffy",
+				"tags": ["", "puffy nipples"],
+				"tooltip": ["When a nipple is more swollen than is common."]
+			},
+			{
+				"name": "Puffy Areola",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is puffy",
+				"tags": ["", "puffy areola"],
+				"tooltip": ["When the areola is bulging more than is common."]
 			}
 		]
 	},
@@ -618,16 +648,16 @@ const BODY_TYPES: Array[Dictionary] = [
 				"value": 2
 			},
 			{
-				"name": "Veiny",
-				"mode": TreeItem.CELL_MODE_CHECK,
-				"text": "Is veiny",
-				"tags": ["", "veiny penis"]
-			},
-			{
 				"name": "Anatomically correct",
 				"mode": TreeItem.CELL_MODE_CHECK,
 				"text": "Is correct",
 				"tags": ["", "anatomically correct penis"]
+			},
+			{
+				"name": "Veiny",
+				"mode": TreeItem.CELL_MODE_CHECK,
+				"text": "Is veiny",
+				"tags": ["", "veiny penis"]
 			},
 		]},
 	{
@@ -1058,7 +1088,7 @@ func apply_character(character_index: int) -> void:
 			if prop_data["use"]:
 				target.disable_folding = false
 
-			var max_prop: int = prop_data["properties"].size()
+			var max_prop: int = prop_data["properties"].size() - 1
 			for prop_idx in range(target.get_child_count()):
 				if max_prop < prop_idx:
 					break


### PR DESCRIPTION
- Added more properties to the wizard's characters
- Fixed error caused when a tag returned with no suggestions (esix API)
	- Fixes #27 
- Fixed alt lists breaking when creating a new list when your current list has alts.
	- Fixes #28  
- Added a toggle for running with argument --verbose
- Optimized database calls. Reduced calls on tag importing.
- Fixed several typos on the wizard
- Fixed default value on database creation for prefixes.
-  Fixed the importer not assigning group suggestions to imported tags
- Fixed moving tags from project to batch dowloader causing an array index overflow
	- Fixes #29 