### PR TITLE
3.5.0: Bugfixes

### DIFF
--- a/scenes/tagit_main_window.gd
+++ b/scenes/tagit_main_window.gd
@@ -2385,20 +2385,13 @@ func on_create_icon_pressed() -> void:
 	new_icon_select.focus_first()
 	var response: Array = await new_icon_select.icon_finished
 	if response[0]:
-		var icon_id: int = SingletonManager.TagIt.save_icon(response[1], response[2])
+		SingletonManager.TagIt.save_icon(response[1], response[2])
 		generate_icon_range()
 		settings_category_tree.icon_range = icon_range.size() - 1
 		settings_category_tree.icon_string = generate_icon_string()
-		settings_icons_tree.add_icon(icon_id, response[1], SingletonManager.TagIt.get_icon_texture(icon_id))
-
 
 func generate_icon_string() -> String:
-	var icon_string: String = ""
-	for icon_id in icon_range:
-		icon_string += SingletonManager.TagIt.get_icon_name(icon_id) #SingletonManager.TagIt.icons[icon_id]["name"]
-		if icon_id != icon_range.back():
-			icon_string += ","
-	return icon_string
+	return ",".join(SingletonManager.TagIt.get_icon_names())
 
 
 func on_delete_icon(id: int) -> void:

--- a/scenes/tagit_main_window.gd
+++ b/scenes/tagit_main_window.gd
@@ -2393,7 +2393,10 @@ func on_create_icon_pressed() -> void:
 
 
 func generate_icon_string() -> String:
-	return ",".join(SingletonManager.TagIt.get_icon_names())
+	var icons: Array[String] = []
+	for icon_id in icon_range:
+		icons.append(SingletonManager.TagIt.get_icon_name(icon_id))
+	return ",".join(icons)
 
 
 func on_delete_icon(id: int) -> void:

--- a/scenes/tagit_main_window.gd
+++ b/scenes/tagit_main_window.gd
@@ -2389,6 +2389,8 @@ func on_create_icon_pressed() -> void:
 		generate_icon_range()
 		settings_category_tree.icon_range = icon_range.size() - 1
 		settings_category_tree.icon_string = generate_icon_string()
+	new_icon_select.queue_free()
+
 
 func generate_icon_string() -> String:
 	return ",".join(SingletonManager.TagIt.get_icon_names())

--- a/scenes/update_window.tscn
+++ b/scenes/update_window.tscn
@@ -89,8 +89,7 @@ layout_mode = 2
 size_flags_vertical = 3
 bbcode_enabled = true
 text = "[font_size=20][b][color=SKY_BLUE]Fixes[/color][/b][/font_size]
-[ul] Fixed an issue preventing changing the picture on existing projects.
- Fixed tabs listening for input when they shouldn't be.[/ul]
-
-[font_size=20][b][color=SKY_BLUE]Changed[/color][/b][/font_size]
-[ul] Added more tooltips to the wizard & wizard characters tool.[/ul]"
+[ul] Fixed an issue with the database that affected previously created tags not appearing and not being able to be registered.
+ Fixed an issue with the icons that appered twice when adding them.
+ Fixed an issue of TagIt not releasing from memory an object when adding icons.
+ Corrected the database holding to an unecessary table if you updated from an old version.[/ul]"

--- a/scripts/singleton_manager.gd
+++ b/scripts/singleton_manager.gd
@@ -36,4 +36,6 @@ func reload_singletons() -> void:
 	if not eSixAPI.is_node_ready():
 		await eSixAPI.ready
 	
+	await get_tree().create_timer(0.1).timeout
+	
 	singletons_ready.emit()

--- a/scripts/tagit_singleton.gd
+++ b/scripts/tagit_singleton.gd
@@ -20,10 +20,10 @@ signal icon_created(icon_id: int)
 
 const DATABASE_PATH: String = "user://tag_database.db"
 const SEARCH_WILDCARD: String = "*"
-const DB_VERSION: int = 3
+const DB_VERSION: int = 4
 const PROJECTS_VERSION: int = 2
 const TEMPLATES_VERSION: int = 3
-const TAGIT_VERSION_ARRAY: Array[int] = [3, 4, 2]
+const TAGIT_VERSION_ARRAY: Array[int] = [3, 5, 0]
 const MAX_PARENT_RECURSION: int = 100
 const IMAGE_LIMITS: Vector2i = Vector2i(1000, 1000)
 const LEV_DISTANCE: float = 0.75
@@ -327,7 +327,8 @@ func update_tables(current_version: int) -> void:
 					"id = " + str(h_prefix["category_id"]),
 					{"hydrus_prefix": h_prefix["prefix"]})
 			
-			tag_database.drop_table("hydrus_prefixes")
+		tag_database.drop_table("hydrus_prefixes")
+		
 		log_silent(
 				"Database updated from version 1 to version 2.",
 				DataManager.LogLevel.INFO)
@@ -370,6 +371,27 @@ func update_tables(current_version: int) -> void:
 					"Database updated from version 2 to version 3.",
 					DataManager.LogLevel.INFO)
 		update_version += 1
+	
+	# Changes in version 3 -> 4
+	# Remove unused table. Used wrong indentation in version 2, causing it to persist
+	# Remove duplicate tag entries caused by a bug in versions 3.4.0 and lower.
+	if update_version == 3:
+		tag_database.query(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name='hydrus_prefixes';")
+		
+		if not tag_database.query_result.is_empty():
+			tag_database.drop_table("hydrus_prefixes")
+		
+		tag_database.query(
+			"DELETE FROM tags 
+			WHERE rowid NOT IN (
+				SELECT MIN(rowid) 
+				FROM tags 
+				GROUP BY name
+			);")
+		log_silent(
+				"Database updated from version 3 to version 4.",
+				DataManager.LogLevel.INFO)
 
 
 # Ensures that all required tables exist. Only checks for tables, not columns.
@@ -489,6 +511,14 @@ func verify_db_tables(tables: Array) -> void:
 
 func get_icon_name(icon_id: int) -> String:
 	return icons[icon_id]["name"]
+
+
+func get_icon_names() -> Array[String]:
+	var names: Array[String] = []
+	for icon_id in icons:
+		names.append(icons[icon_id]["name"])
+	return names
+	
 
 
 func get_category_icon_color(category_id: int) -> Color:


### PR DESCRIPTION
- Fixed an issue with the database that affected previously created tags not appearing and not being able to be registered.
- Fixed an issue with the icons that appered twice when adding them.
- Fixed an issue of TagIt not releasing from memory an object when adding icons.
- Corrected the database holding to an unecessary table if you updated from an old version.